### PR TITLE
ADM remediating 17 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,32 +124,32 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.67_noneautotype2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>30.0-android</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.35</version>
+            <version>8.0.31</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>6.1.0.jre8</version>
+            <version>10.1.0.jre8-preview</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.0.17</version>
+            <version>1.2.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -184,12 +184,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.0.6</version>
+            <version>1.2.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.6</version>
+            <version>1.2.8</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Vulnerabilities:
* CVE-2021-33800: com.alibaba:druid:1.0.17
* CVE-2017-5929: ch.qos.logback:logback-classic:1.0.6
* -: com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8
* CVE-2017-5929, CVE-2021-42550: ch.qos.logback:logback-core:1.0.6
* CVE-2017-3523, CVE-2017-3586, CVE-2017-3589, CVE-2018-3258, CVE-2019-2692, CVE-2020-2875, CVE-2020-2933, CVE-2020-2934, CVE-2022-21363: mysql:mysql-connector-java:5.1.35
* CVE-2017-18349, CVE-2022-25845: com.alibaba:fastjson:1.2.8
* CVE-2021-29425: commons-io:commons-io:2.4
* CVE-2018-10237, CVE-2020-8908: com.google.guava:guava:19.0

Dependencies upgraded:
* ch.qos.logback:logback-classic:1.0.6 -> 1.2.8
* ch.qos.logback:logback-core:1.0.6 -> 1.2.8
* com.alibaba:druid:1.0.17 -> 1.2.4
* com.alibaba:fastjson:1.2.8 -> 1.2.67_noneautotype2
* com.google.guava:guava:19.0 -> 30.0-android
* com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8 -> 10.1.0.jre8-preview
* commons-io:commons-io:2.4 -> 2.7
* mysql:mysql-connector-java:5.1.35 -> 8.0.31

Auto-merge is enabled